### PR TITLE
Add personal profile info

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders Front-End heading', () => {
+test('renders profile heading', () => {
   render(<App />);
-  const headingElement = screen.getByText(/Front-End/i);
+  const headingElement = screen.getByText(/Rayhan Wilangkara/i);
   expect(headingElement).toBeInTheDocument();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,24 +1,13 @@
-import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import React from 'react';
 
 const App: React.FC = () => {
-  const [data, setData] = useState<string | null>(null);
-
-  useEffect(() => {
-    // Make a GET request to the back-end API
-    axios.get('http://localhost:5000/api/data')
-      .then(response => {
-        setData(response.data.message);
-      })
-      .catch(error => {
-        console.error('There was an error fetching the data!', error);
-      });
-  }, []);
-
   return (
     <div>
-      <h1>Front-End</h1>
-      <p>Message from back-end: {data}</p>
+      <h1>Rayhan Wilangkara</h1>
+      <p>
+        I'm a Master's student at Arizona State University working towards an MS
+        in Computer Science, expected graduation 2027.
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- put real profile content on the home page
- update test to match new heading

## Testing
- `CI=true npm test --prefix frontend --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6872cce333b483288aed3ba3fd0103ca